### PR TITLE
Support function declarations without the function keyword

### DIFF
--- a/BashScriptTestingLibrary.shl
+++ b/BashScriptTestingLibrary.shl
@@ -196,7 +196,13 @@ __containsCallback() {
 
 runUnitTests () {
     START_TIME=$(date +%s)
-    test_names=$(grep -E '^test.*?\(' $0 | tr -d ' (){')
+    # Explanation of the following command:
+    # grep - E               - Use extended regexp
+    # ^(function )?          - Lines may start with the keyword function followed by space
+    # test.*?\(              - Match any line with 'test[anything] (', doesn't need 'function'
+    # sed 's/^function //'   - Remove the 'function ' prefix from any string, if it occurs
+    # tr - d ' (){'          - Remove the trailing ' (){' characters
+    test_names=$(grep -E '^(function )?test.*?\(' $0 | sed 's/^function //' | tr -d ' (){')
     test_names_array=($test_names)
 
     beginUnitTests

--- a/BashScriptTestingLibrary.shl
+++ b/BashScriptTestingLibrary.shl
@@ -48,7 +48,7 @@ function assertEquals () {
         "${1}"
         "${2}"
     )
-    __assert 2 __equalsCallback args[@] "$#" "Expected \"$1\", but got \"$2\"." 
+    __assert 2 __equalsCallback args[@] "$#" "Expected \"$1\", but got \"$2\"."
 }
 
 function assertNotEquals () {
@@ -92,7 +92,7 @@ function assertContains () {
         "${1}"
         "${2}"
     )
-    __assert 2 __containsCallback args[@] "$#" "Expected \"$2\" to contain \"$1\"." 
+    __assert 2 __containsCallback args[@] "$#" "Expected \"$2\" to contain \"$1\"."
 }
 
 # Main assert function, DONT CALL THIS DIRECTLY!
@@ -111,7 +111,7 @@ __assert () {
         local result=$(${callback_function} ${callback_args})
 
         if [ ${result} = "true" ]; then
-            [[ "$VERBOSE_MODE" = "true" ]] && echo "Line ${line}: Passed - ${test_case_calling_assert}" 
+            [[ "$VERBOSE_MODE" = "true" ]] && echo "Line ${line}: Passed - ${test_case_calling_assert}"
             incrementPassedTests
         else
             echo "Line ${line}: ${test_case_calling_assert}: ${assert_caller_func_name}() failed. $failure_msg"
@@ -196,7 +196,7 @@ __containsCallback() {
 
 function runUnitTests () {
     START_TIME=$(date +%s)
-    test_names=$(grep "^function test" $0 | awk '{print $2}' | cut -f 1 -d "(")
+    test_names=$(grep -E '^(function )?test.*?\(' $0 | sed 's/^function //' | tr -d ' (){')
     test_names_array=($test_names)
 
     beginUnitTests
@@ -260,4 +260,3 @@ function correctNumberOfArgs () {
 function numericCompare () {
     awk -v n1=$1 -v n2=$2 \ 'BEGIN { print (n1 == n2) ? "true" : "false" }' 2>/dev/null
 }
-

--- a/BashScriptTestingLibrary.shl
+++ b/BashScriptTestingLibrary.shl
@@ -6,7 +6,7 @@ total_tests=0
 VERBOSE_MODE="false"
 NO_SCREEN_CLEAR="false"
 
-function showHelp () {
+showHelp () {
     echo "Usage:"
     echo "  unitTestSuite.ut [options]"
     echo ""
@@ -18,7 +18,7 @@ function showHelp () {
     echo ""
 }
 
-function showVersion () {
+showVersion () {
     echo ""
     echo "BashScriptTestingLibrary: Version 1.0.0"
     echo ""
@@ -43,7 +43,7 @@ done
 
 # Assert Functions
 
-function assertEquals () {
+assertEquals () {
     local args=(
         "${1}"
         "${2}"
@@ -51,7 +51,7 @@ function assertEquals () {
     __assert 2 __equalsCallback args[@] "$#" "Expected \"$1\", but got \"$2\"."
 }
 
-function assertNotEquals () {
+assertNotEquals () {
     local args=(
         "${1}"
         "${2}"
@@ -59,35 +59,35 @@ function assertNotEquals () {
     __assert 2 __notEqualsCallback args[@] "$#" "Expected not \"$1\", but got \"$2\"."
 }
 
-function assertNull () {
+assertNull () {
     local args=(
         "${1}"
     )
     __assert 1 __nullCallback args[@] "$#" "Expected empty string, but got \"$1\"."
 }
 
-function assertNotNull () {
+assertNotNull () {
     local args=(
         "${1}"
     )
     __assert 1 __notNullCallback args[@] "$#" "Expected not empty string, but got \"$1\"."
 }
 
-function assertTrue () {
+assertTrue () {
     local args=(
         "${1}"
     )
     __assert 1 __trueCallback args[@] "$#" "Boolean Expression [ $1 ] expected to evaluate as true, evaluated as false."
 }
 
-function assertFalse () {
+assertFalse () {
     local args=(
         "${1}"
     )
     __assert 1 __falseCallback args[@] "$#" "Boolean Expression [ $1 ] expected to evaluate as false, evaluated as true."
 }
 
-function assertContains () {
+assertContains () {
     local args=(
         "${1}"
         "${2}"
@@ -194,9 +194,9 @@ __containsCallback() {
 
 # Utility functions
 
-function runUnitTests () {
+runUnitTests () {
     START_TIME=$(date +%s)
-    test_names=$(grep -E '^(function )?test.*?\(' $0 | sed 's/^function //' | tr -d ' (){')
+    test_names=$(grep -E '^test.*?\(' $0 | tr -d ' (){')
     test_names_array=($test_names)
 
     beginUnitTests
@@ -216,7 +216,7 @@ function runUnitTests () {
     fi
 }
 
-function beginUnitTests () {
+beginUnitTests () {
     if [ $NO_SCREEN_CLEAR = "false" ]; then
         clear
     fi
@@ -225,7 +225,7 @@ function beginUnitTests () {
     echo ""
 }
 
-function endUnitTests () {
+endUnitTests () {
 
     if [ $failed_tests = 0 ] && [ $VERBOSE_MODE = "false" ]; then
         echo "All unit tests passed."
@@ -235,21 +235,21 @@ function endUnitTests () {
     echo "RESULTS: $passed_tests tests passed.  $failed_tests tests failed.  $total_tests tests total."
 }
 
-function incrementPassedTests () {
+incrementPassedTests () {
     passed_tests=$(($passed_tests+1))
     incrementTotalTests
 }
 
-function incrementFailedTests () {
+incrementFailedTests () {
     failed_tests=$(($failed_tests+1))
     incrementTotalTests
 }
 
-function incrementTotalTests () {
+incrementTotalTests () {
     total_tests=$(($total_tests+1))
 }
 
-function correctNumberOfArgs () {
+correctNumberOfArgs () {
     if [ $1 = $2 ]; then
         echo "true"
     else
@@ -257,6 +257,6 @@ function correctNumberOfArgs () {
     fi
 }
 
-function numericCompare () {
+numericCompare () {
     awk -v n1=$1 -v n2=$2 \ 'BEGIN { print (n1 == n2) ? "true" : "false" }' 2>/dev/null
 }

--- a/README.md
+++ b/README.md
@@ -1,9 +1,9 @@
 # Bash Script Testing Library (BSTL)
-...is a unit testing framework for Shell scripts - namely Bash.  
+...is a unit testing framework for Shell scripts - namely Bash.
 
 This is a very light weight (as in one file) unit testing library for Bash scripts.  It functions similarly to Java's JUnit.
 
-You do not need to touch any of your shell scripts to run unit tests against it.  That is to say, that your original source code does not need to know about the BSTL in order for the unit tests to work.  
+You do not need to touch any of your shell scripts to run unit tests against it.  That is to say, that your original source code does not need to know about the BSTL in order for the unit tests to work.
 
 -----
 
@@ -17,19 +17,19 @@ Simply add the following lines underneath your shebang (`#!/bin/bash`) in your u
 Next, you can create any test case you like, such as:
 
 ```
-function testScriptVariableEquals5 () {
+testScriptVariableEquals5 () {
     someScriptFunctionThatSetsScriptVarToFive
     assertEquals $ScriptVar 5
-} 
+}
 ```
 
 You can also evaluate that certian conditions have been met, such as a process was started:
 
 ```
-function testMyProcessStarted () {
+testMyProcessStarted () {
     someScriptFunctionThatStartsMyProcess
     assertTrue "pgrep myProcess.sh > /dev/null"
-} 
+}
 ```
 
 At the very bottom of your unit test suite, you need to call the function `runUnitTests`.
@@ -40,24 +40,24 @@ When you are ready to run your unit test suite, simply run it as you would any o
 ./MyUnitTestSuite.ut
 ```
 
-Or you can run it verbosely using the `-v` or `--verbose` flags, which will print out all test case results, even if they pass.  
+Or you can run it verbosely using the `-v` or `--verbose` flags, which will print out all test case results, even if they pass.
 
 ```
 ./MyUnitTestSuite.ut -v
 ./MyUnitTestSuite.ut --verbose
-``` 
+```
 
 -----
 ### !!! IMPORTANT NOTE !!!
 Your unit test suite is a shell script! Therefore, if you run a dangerous command, you are going to get dangerous results! For example,
 
 ```
-function testCanDeleteHomeDirectory() {
+testCanDeleteHomeDirectory() {
     rm -rf ~
     assertTrue " ! -d ~ "
 }
 ```
-This will absolutely delete your home directory and the assertTrue function will return a valid result, because you just blew away your home directory.  Pay attention to your commands!  
+This will absolutely delete your home directory and the assertTrue function will return a valid result, because you just blew away your home directory.  Pay attention to your commands!
 
 -----
 
@@ -86,13 +86,13 @@ assertContains needle haystack
 
 ### Important Notes:
 
-1. Only functions prefixed with `test`, i.e: `function test<functionName>` inside of the unit test suite will be executed.
+1. Only functions prefixed with `test`, i.e: `test<functionName>` inside of the unit test suite will be executed.
 
 2. Null is considered to be empty string `""`. The assertNull requires you to enclose your argument in quotes.
 
 3. You must include quotes around conditional expressions.  These expressions can be anything that can be evaluated in an if statement condition.  Example: `"-f someFile.txt"`
 
-4. The extension `.shl` is an extension I perfer to give to library shell scripts.  It stands for `.shellLibrary`. 
+4. The extension `.shl` is an extension I perfer to give to library shell scripts.  It stands for `.shellLibrary`.
 
 5. The extension `.ut` is an extension I prefer to give to unit test suites.  It stands for `.unitTest`.
 
@@ -102,14 +102,14 @@ assertContains needle haystack
 
 8. If any of your unit tests fail, the script will exit after all tests have run, with a status code of 1.
 
-9. If you need to test commands that delete files or directories, it is strongly recommended to use a `testSetup()` function at the top of your unit test suite, and use it to create temporary 
+9. If you need to test commands that delete files or directories, it is strongly recommended to use a `testSetup()` function at the top of your unit test suite, and use it to create temporary
 files or directories that you are intentionally trying to delete.  This probably goes without saying but, DO NOT TEST `rm` COMMANDS AGAINST PRODUCTION DATA!!!
 
-10. If you wish, you can also use a `testTearDown()` function at the bottom of your unit test suite, to clean up your tests. 
+10. If you wish, you can also use a `testTearDown()` function at the bottom of your unit test suite, to clean up your tests.
 
-11. You can change the name of `testSetup()` and `testTearDown()`.  They are not hard coded.  Refer to point #1.  
+11. You can change the name of `testSetup()` and `testTearDown()`.  They are not hard coded.  Refer to point #1.
 
-12. Please see the unit tests in `bstl_unit_tests` and in `examples` for more examples.  
+12. Please see the unit tests in `bstl_unit_tests` and in `examples` for more examples.
 
 -----
 

--- a/bstl_unit_tests/UnitTestsWithIntentionalFailures.ut
+++ b/bstl_unit_tests/UnitTestsWithIntentionalFailures.ut
@@ -2,213 +2,213 @@
 
 source ../BashScriptTestingLibrary.shl
 
-function testSetup () {
+testSetup () {
     touch testFile
 }
 
-function testAssertEqualsWithStrings () {
+testAssertEqualsWithStrings () {
     assertEquals "something" "something"
-} 
+}
 
 
-function testAssertEqualsWithIntegers () {
+testAssertEqualsWithIntegers () {
     assertEquals 10 10
-} 
+}
 
 
-function testAssertEqualsWithIntegers2 () {
+testAssertEqualsWithIntegers2 () {
     assertEquals 5 $((10 - 5))
 }
 
 
-function testAssertEqualsWithIntegers3 () {
+testAssertEqualsWithIntegers3 () {
     assertEquals 1 1
 }
 
 
-function testAssertEqualsWithDoubles () {
+testAssertEqualsWithDoubles () {
     assertEquals 5.5 5.5
 }
 
 
-function testAssertEqualsWithDoubles2 () {
+testAssertEqualsWithDoubles2 () {
     assertEquals 5.5 5.50
 }
 
 
-function testAssertEqualsWithArrays () {
+testAssertEqualsWithArrays () {
     local array1=(1,2,3)
     local array2=(1,2,3)
     assertEquals $array1 $array2
 }
 
 
-function testAssertNotEqualsWithStrings () {
+testAssertNotEqualsWithStrings () {
     assertNotEquals "something" "something else"
 }
 
 
-function testAssertNotEqualsWithIntegers () {
+testAssertNotEqualsWithIntegers () {
     assertNotEquals 5 6
 }
 
 
-function testAssertNotEqualsWithArrays () {
+testAssertNotEqualsWithArrays () {
     local array1=(1,2,3)
     local array2=(4,5,6)
-    assertNotEquals $array1 $array2 
+    assertNotEquals $array1 $array2
 }
 
 
-function testAssertNull () {
+testAssertNull () {
     nullString=""
     assertNull "$nullString"
 }
 
 
-function testAssertTrueWithFilename () {
+testAssertTrueWithFilename () {
     assertTrue  "-f \"testFile\""
 }
 
 
-function testAssertTrueWithIntegers () {
+testAssertTrueWithIntegers () {
     assertTrue "10 = 10"
 }
 
 
-function testAssertFalseWithIntegers () {
+testAssertFalseWithIntegers () {
     assertFalse "10 = 5"
 }
 
 
-function testAssertFalseWithFilename () {
+testAssertFalseWithFilename () {
     assertFalse  "-f \"testFile2\""
 }
 
 
-function testAssertFalseWithArray () {
+testAssertFalseWithArray () {
     local array1=(1,2,3)
     local array2=(4,5,6)
-    assertFalse "${array1} = ${array2}" 
+    assertFalse "${array1} = ${array2}"
 }
 
-function testAssertContainsWithString () {
+testAssertContainsWithString () {
     local string="FooBar"
     local substring="Bar"
     assertContains $substring $string
 }
 
-function testAssertContainsWithArray () {
+testAssertContainsWithArray () {
     local array1=(1,2,3)
     local num2=2
     assertContains $num2 $array1
 }
 
-function testAssertEqualsWithStringsFailure () {
+testAssertEqualsWithStringsFailure () {
     assertEquals "something" "something else"
 }
 
 
-function testAssertEqualsWithIntegersFailure () {
+testAssertEqualsWithIntegersFailure () {
     assertEquals 5 10
 }
 
 
-function testAssertEqualsWithArraysFailure () {
+testAssertEqualsWithArraysFailure () {
     local array1=(1,2,3)
     local array2=(4,5,6)
     assertEquals $array1 $array2
 }
 
 
-function testAssertNotEqualsWithIntegersFailure () {
+testAssertNotEqualsWithIntegersFailure () {
     assertNotEquals 5 5
 }
 
 
-function testAssertNotEqualsWithStringsFailure () {
+testAssertNotEqualsWithStringsFailure () {
     assertNotEquals "same" "same"
 }
 
 
-function testAssertNotEqualsWithArrayFailure () {
+testAssertNotEqualsWithArrayFailure () {
     local array1=(1,2,3)
     local array2=(1,2,3)
     assertNotEquals $array1 $array2
 }
 
 
-function testAssertNullWithIntegerFailure () {
+testAssertNullWithIntegerFailure () {
     assertNull 5
 }
 
 
-function testAssertNullWithStringFailure () {
+testAssertNullWithStringFailure () {
     assertNull "something"
 }
 
 
-function testAssertNullWithArrayFailure () {
+testAssertNullWithArrayFailure () {
     local array1=(1,2,3)
     assertNull $array1
 }
 
 
-function testAssertTrueWithFilenameFailure () {
+testAssertTrueWithFilenameFailure () {
     assertTrue  "-f \"testFile2\""
 }
 
 
-function testAssertTrueWithIntegersFailure () {
+testAssertTrueWithIntegersFailure () {
     assertTrue  "10 = 5"
 }
 
 
-function testAssertFalseWithFilenameFailure () {
+testAssertFalseWithFilenameFailure () {
     assertFalse "-f \"testFile\""
 }
 
-function testAssertFalseWithIntegersFailure () {
+testAssertFalseWithIntegersFailure () {
     assertFalse "10 = 10"
 }
 
-function testAssertContainsWithStringsFailure () {
+testAssertContainsWithStringsFailure () {
     local string="FooBar"
     local substring="BarBar"
     assertContains $substring $string
 }
 
-function testAssertContainsWithArrayFailure () {
+testAssertContainsWithArrayFailure () {
     local array1=(4,5,6)
     local num2=7
     assertContains $num2 $array1
 }
 
-function testAssertEqualsWrongArgsNum() {
+testAssertEqualsWrongArgsNum() {
     assertEquals "something"
 }
 
-function testAssertNotEqualsWrongArgsNum() {
+testAssertNotEqualsWrongArgsNum() {
     assertNotEquals 20
 }
 
-function testAssertNullWrongArgsNum() {
+testAssertNullWrongArgsNum() {
     assertNull
 }
 
-function testAssertTrueWrongArgsNum() {
+testAssertTrueWrongArgsNum() {
     assertTrue
 }
 
-function testAssertFalseWrongArgsNum() {
+testAssertFalseWrongArgsNum() {
     assertFalse
 }
 
-function testAssertContainsWrongArgsNum() {
+testAssertContainsWrongArgsNum() {
     assertContains "Foo"
 }
 
-function testTeardown () {
+testTeardown () {
     rm testFile
 }
 

--- a/bstl_unit_tests/UnitTestsWithNoFailures.ut
+++ b/bstl_unit_tests/UnitTestsWithNoFailures.ut
@@ -2,122 +2,114 @@
 
 source ../BashScriptTestingLibrary.shl
 
-function testSetup () {
+testSetup () {
     touch testFile
 }
 
 
-function testAssertEqualsWithStrings () {
+testAssertEqualsWithStrings () {
     assertEquals "something" "something"
 }
 
 
-function testAssertEqualsWithIntegers () {
+testAssertEqualsWithIntegers () {
     assertEquals 10 10
 }
 
 
-function testAssertEqualsWithIntegers2 () {
+testAssertEqualsWithIntegers2 () {
     assertEquals 5 $((10 - 5))
 }
 
 
-function testAssertEqualsWithIntegers3 () {
+testAssertEqualsWithIntegers3 () {
     assertEquals 1 1
 }
 
 
-function testAssertEqualsWithDoubles () {
+testAssertEqualsWithDoubles () {
     assertEquals 5.5 5.5
 }
 
 
-function testAssertEqualsWithDoubles2 () {
+testAssertEqualsWithDoubles2 () {
     assertEquals 5.5 5.50
 }
 
 
-function testAssertEqualsWithArrays () {
+testAssertEqualsWithArrays () {
     local array1=(1,2,3)
     local array2=(1,2,3)
     assertEquals $array1 $array2
 }
 
 
-function testAssertNotEqualsWithStrings () {
+testAssertNotEqualsWithStrings () {
     assertNotEquals "something" "something else"
 }
 
 
-function testAssertNotEqualsWithIntegers () {
+testAssertNotEqualsWithIntegers () {
     assertNotEquals 5 6
 }
 
 
-function testAssertNotEqualsWithArrays () {
+testAssertNotEqualsWithArrays () {
     local array1=(1,2,3)
     local array2=(4,5,6)
     assertNotEquals $array1 $array2
 }
 
 
-function testAssertNull () {
+testAssertNull () {
     nullString=""
     assertNull "$nullString"
 }
 
 
-function testAssertTrueWithFilename () {
+testAssertTrueWithFilename () {
     assertTrue  "-f \"testFile\""
 }
 
 
-function testAssertTrueWithIntegers () {
+testAssertTrueWithIntegers () {
     assertTrue "10 = 10"
 }
 
 
-function testAssertFalseWithIntegers () {
+testAssertFalseWithIntegers () {
     assertFalse "10 = 5"
 }
 
 
-function testAssertFalseWithFilename () {
+testAssertFalseWithFilename () {
     assertFalse  "-f \"testFile2\""
 }
 
 
-function testAssertFalseWithArray () {
+testAssertFalseWithArray () {
     local array1=(1,2,3)
     local array2=(4,5,6)
     assertFalse "${array1} = ${array2}"
 }
 
 
-function testAssertContainsWithString () {
+testAssertContainsWithString () {
     local string="FooBar"
     local substring="Bar"
     assertContains $substring $string
 }
 
 
-function testAssertContainsWithArray () {
+testAssertContainsWithArray () {
     local array1=(1,2,3)
     local num2=2
     assertContains $num2 $array1
 }
 
 
-function testTeardown () {
+testTeardown () {
     rm testFile
-}
-
-testNoFunctionKeyword () {
-    assertEquals "Hello" "Hello"
-}
-
-testNoFunctionKeywordNoSpace() {
-    assertEquals "Hello" "Hello"
 }
 
 runUnitTests

--- a/bstl_unit_tests/UnitTestsWithNoFailures.ut
+++ b/bstl_unit_tests/UnitTestsWithNoFailures.ut
@@ -9,12 +9,12 @@ function testSetup () {
 
 function testAssertEqualsWithStrings () {
     assertEquals "something" "something"
-} 
+}
 
 
 function testAssertEqualsWithIntegers () {
-    assertEquals 10 10 
-} 
+    assertEquals 10 10
+}
 
 
 function testAssertEqualsWithIntegers2 () {
@@ -41,7 +41,7 @@ function testAssertEqualsWithArrays () {
     local array1=(1,2,3)
     local array2=(1,2,3)
     assertEquals $array1 $array2
-} 
+}
 
 
 function testAssertNotEqualsWithStrings () {
@@ -57,7 +57,7 @@ function testAssertNotEqualsWithIntegers () {
 function testAssertNotEqualsWithArrays () {
     local array1=(1,2,3)
     local array2=(4,5,6)
-    assertNotEquals $array1 $array2 
+    assertNotEquals $array1 $array2
 }
 
 
@@ -90,7 +90,7 @@ function testAssertFalseWithFilename () {
 function testAssertFalseWithArray () {
     local array1=(1,2,3)
     local array2=(4,5,6)
-    assertFalse "${array1} = ${array2}" 
+    assertFalse "${array1} = ${array2}"
 }
 
 
@@ -110,6 +110,14 @@ function testAssertContainsWithArray () {
 
 function testTeardown () {
     rm testFile
+}
+
+testNoFunctionKeyword () {
+    assertEquals "Hello" "Hello"
+}
+
+testNoFunctionKeywordNoSpace() {
+    assertEquals "Hello" "Hello"
 }
 
 runUnitTests

--- a/bstl_unit_tests/runUnitTestSuite.ut
+++ b/bstl_unit_tests/runUnitTestSuite.ut
@@ -6,7 +6,7 @@
 
 source ../BashScriptTestingLibrary.shl
 
-function testRunUnitTestSuite () {
+testRunUnitTestSuite () {
     ./UnitTestsWithIntentionalFailures.ut
     ./UnitTestsWithNoFailures.ut
     ./UnitTestsWithIntentionalFailures.ut -v

--- a/examples/myScript.sh
+++ b/examples/myScript.sh
@@ -1,24 +1,24 @@
 #!/bin/bash
 
-# This script has no real purpose other than to contain functions for unit tests to call. 
+# This script has no real purpose other than to contain functions for unit tests to call.
 
 script_var=""
 
-function main () {
+main () {
     setScriptVarToFive
     createSomeLogFile
     startMyProcess
 }
 
-function setScriptVarToFive () {
+setScriptVarToFive () {
     script_var=5
 }
 
-function createSomeLogFile () {
+createSomeLogFile () {
     echo "Some Sample Text" > logfile.log
 }
 
-function startMyProcess () {
+startMyProcess () {
     /bin/bash &
 }
 

--- a/examples/myScriptUnitTest.ut
+++ b/examples/myScriptUnitTest.ut
@@ -3,24 +3,24 @@
 source ../BashScriptTestingLibrary.shl
 source myScript.sh
 
-function testSetScriptVarToFive () {
+testSetScriptVarToFive () {
     setScriptVarToFive
     assertEquals 5 $script_var
 }
 
-function testCreateSomeLogFile () {
+testCreateSomeLogFile () {
     createSomeLogFile
     assertTrue "-f logfile.log"
     assertEquals "Some Sample Text" "$(cat logfile.log)"
 }
 
-function testStartMyProcess () {
+testStartMyProcess () {
     startMyProcess
     result=$(ps -ef | grep -v "grep" | grep /bin/bash | wc -l)
     assertTrue " $result -gt 0 "
 }
 
-function testTearDown () {
+testTearDown () {
     rm logfile.log
 }
 


### PR DESCRIPTION
See: http://mywiki.wooledge.org/BashPitfalls#function_foo.28.29

Using the function keyword is generally discouraged and many people
never use the keyword and simply use the syntax `funcName()` or
`funcName ()`. Both of these styles are now supported along with
the use of `function`. There are two new tests in UnitTestsWithNoFailures.ut
One has no space between the name and parens and the other does.

The minor changes on several lines is due to trailing whitespace
my editor removed.